### PR TITLE
Fixed instructions for current rails version

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ require 'ci/reporter/rake/minitest'
 # Rake code that creates a task called `:minitest`
 # ...
 
-task :minitest => 'ci:setup:minitest'
+task :test => 'ci:setup:minitest'
 ```
 
 ### Advanced usage


### PR DESCRIPTION
minitest task doesn't exist anymore, hook into rake test directly does work.
