### PR TITLE
Replace result.class with result.klass

### DIFF
--- a/lib/ci/reporter/minitest.rb
+++ b/lib/ci/reporter/minitest.rb
@@ -77,13 +77,13 @@ module CI
         # suite we are in, and is only called at the granularity of a
         # test. We have to work backwards to understand when the suite
         # changes.
-        if @current_suite_class != result.class
+        if @current_suite_class != result.klass
           finish_suite
           start_suite
         end
 
-        @current_suite_class = result.class
-        @current_suite.name = result.class.to_s
+        @current_suite_class = result.klass
+        @current_suite.name = result.klass.to_s
 
         tc = TestCase.new(result.name, result.time, result.assertions)
         tc.failures = result.failures.map {|f| Failure.classify(f)}


### PR DESCRIPTION
`result.class` returns the class of the result object, but what you really want is the name of the test class, which is in `result.klass`.

Currently, all test reports end up in the "Minitest::Result" suite.

I guess there should be a question about whether this breaks compatibility with some earlier version of minitest, whether that matters, and what to do if it does.